### PR TITLE
OpenMP parallel version

### DIFF
--- a/libmue/firstround_select.cpp
+++ b/libmue/firstround_select.cpp
@@ -14,13 +14,13 @@ struct Candidate
 	: distance(distance), team(team)
 	{ }
 
-	bool operator <(Candidate const &other)
+	bool operator <(Candidate const &other) const
 	{ return distance < other.distance; }
 
-	bool operator >(Candidate const &other)
+	bool operator >(Candidate const &other) const
 	{ return distance > other.distance; }
 
-	bool operator ==(Candidate const &other)
+	bool operator ==(Candidate const &other) const
 	{ return team == other.team; }
 };
 

--- a/libmue/mue_algorithm.h
+++ b/libmue/mue_algorithm.h
@@ -157,16 +157,18 @@ class Calculation
 
 		bool _distance_is_better(Distance new_dist) const  { return _best_distance > new_dist; }
 		void run_new_round(Round_data const &round_data, Iteration_data &iteration);
-		void run_distribution(Round_data const &round_data, Iteration_data &iteration, size_t host_index);
+		void run_distribution(Round_data const &round_data, Iteration_data &iteration, size_t host_index, std::vector<std::vector<Guest_candidate>>& candidate_pool);
+		void run_firstround_distribution_seq(Round_data const &round_data, Iteration_data &iteration, size_t host_index);
 		void run_firstround_distribution(Round_data const &round_data, Iteration_data &iteration, size_t host_index);
 		void report_success(Round_data const &round_data, Iteration_data const &iteration);
 		void print_stations(std::vector<std::vector<Team_id> > const &stations);
 
-		std::vector<Guest_candidate> determine_guest_candidates(Round_data const &round_data,
+		std::vector<Guest_candidate>& determine_guest_candidates(Round_data const &round_data,
 									Iteration_data const &iteration_data,
 									Team_id current_host,
 									size_t const &host_idx,
-									size_t slice) const;
+									size_t slice,
+									std::vector<Guest_candidate>& candidates) const;
 
 		void update_best(float best) { _best_distance = best; }
 

--- a/libmue/seen_table.cpp
+++ b/libmue/seen_table.cpp
@@ -1,6 +1,7 @@
 #include "seen_table.h"
 
 #include <boost/assert.hpp>
+#include <string.h>
 
 
 void mue::Seen_table::add_meeting(Team_id id_1, Team_id id_2, Team_id id_3) noexcept
@@ -14,32 +15,30 @@ void mue::Seen_table::add_meeting(Team_id id_1, Team_id id_2, Team_id id_3) noex
 mue::Seen_table::Seen_table(Seen_table const &old, int new_generation) noexcept
 :
 	_generation(new_generation),
-	_max_teams(old._max_teams),
-	_table(old._table)
-{ }
+	_max_teams(old._max_teams)
+{
+	memcpy(_table, old._table, sizeof(*_table) * old._max_teams);
+}
 
 
 mue::Seen_table::Seen_table(Seen_table&& other) noexcept
 :
 	_generation(std::move(other._generation)),
-	_max_teams(std::move(other._max_teams)),
-	_table(std::move(other._table)),
-	_allocated_lines(std::move(other._allocated_lines))
-{ }
+	_max_teams(std::move(other._max_teams))
+{
+	memcpy(_table, other._table, sizeof(*_table) * other._max_teams);
+}
 
 
 mue::Seen_table::Seen_table(int max_teams) noexcept
 :
 	_generation(0),
-	_max_teams(max_teams),
-	_table(max_teams, 0)
+	_max_teams(max_teams)
 {
 	BOOST_ASSERT(max_teams <= MAX_TEAMS);
 
 	for (int i = 0; i < max_teams; ++i) {
-		Seen_data * new_data = new Seen_data(0);
-		_allocated_lines.push_back(new_data);
-		_table[i] = new_data;
+		_table[i] = &_seen_pool[i];
 	}
 
 	if (_id_bitsets.empty()) {
@@ -51,9 +50,6 @@ mue::Seen_table::Seen_table(int max_teams) noexcept
 
 
 mue::Seen_table::~Seen_table()
-{
-	for (Seen_data * data : _allocated_lines)
-		delete data;
-}
+{ }
 
 std::vector<mue::Seen_table::Seen_data::Seen_bitset> mue::Seen_table::_id_bitsets;

--- a/libmue/seen_table.h
+++ b/libmue/seen_table.h
@@ -16,9 +16,10 @@ class Seen_table
 		struct Seen_data {
 			typedef std::bitset<MAX_TEAMS> Seen_bitset;
 
-			int const generation;
+			int generation;
 			Seen_bitset bitset;
 
+			Seen_data() : generation(0), bitset() {}
 			Seen_data(int generation) : generation(generation), bitset() { }
 			Seen_data(int generation, Seen_bitset const &bitset) : generation(generation), bitset(bitset) { }
 			Seen_data(Seen_data const &other) : generation(other.generation + 1), bitset(other.bitset) { }
@@ -29,15 +30,16 @@ class Seen_table
 		int const _generation;
 		int const _max_teams;
 
-		std::vector<Seen_data *> _table;
-		std::list<Seen_data *> _allocated_lines;
+		Seen_data _seen_pool[MAX_TEAMS];
+		Seen_data *_table[MAX_TEAMS]; // this works since we work recursively, the instances we copy the pointers from stay alive.
 
 		Seen_table(Seen_table const &old, int new_generation) noexcept;
 
 		inline void _update_table(Team_id table_idx, Team_id team_a, Team_id team_b) noexcept
 		{
-			Seen_data * new_data = new Seen_data(generation(), _table[table_idx]->bitset | (_id_bitsets[team_a] | _id_bitsets[team_b]));
-			_allocated_lines.push_back(new_data);
+			Seen_data *new_data = &_seen_pool[table_idx];
+			new_data->bitset = _table[table_idx]->bitset | (_id_bitsets[team_a] | _id_bitsets[team_b]);
+			new_data->generation = generation();
 			_table[table_idx] = new_data;
 		}
 


### PR DESCRIPTION
Please pull from my branch changes that enable thread-parallel search for optimal distribution. The parallelization is done using OpenMP tasks to traverse the distribution tree in parallel over all possible first_round guest tuples in parallel. 

The branch also adds some changes to reduce dynamic memory management, mainly in the seen table and in the handling of the guest tuples. 