### PR TITLE
Ensure that all guests are in one of the firstround candidates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,6 @@ RUN DEBIAN_FRONTEND=noninteractive DEBIAN_NONINTERACTIVE_SEEN=true && \
 		libboost-dev \
 		libtcmalloc-minimal4 \
 		libgoogle-perftools4 \
-	&& \
-	apt-get clean && \
-	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN DEBIAN_FRONTEND=noninteractive DEBIAN_NONINTERACTIVE_SEEN=true && \
-	apt-get update && \
-	apt-get -y install --no-install-recommends \
 		cxxtest \
 	&& \
 	apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM debian:jessie
+
+MAINTAINER Jan Losinski <losinski@wh2.tu-dresden.de>
+
+RUN DEBIAN_FRONTEND=noninteractive DEBIAN_NONINTERACTIVE_SEEN=true && \
+	apt-get update && \
+	apt-get -y install --no-install-recommends \
+		build-essential \
+		cmake \
+		g++-4.9 \
+		libboost-python-dev \
+		python3.4-dev \
+		libboost-dev \
+		libtcmalloc-minimal4 \
+		libgoogle-perftools4 \
+	&& \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN DEBIAN_FRONTEND=noninteractive DEBIAN_NONINTERACTIVE_SEEN=true && \
+	apt-get update && \
+	apt-get -y install --no-install-recommends \
+		cxxtest \
+	&& \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN groupadd user && \
+	useradd --uid 1000 --create-home --home-dir /home/user -g user user
+
+RUN mkdir /plandata && \
+	chown user:user /plandata
+
+WORKDIR /home/user
+USER user
+
+ADD . /home/user/src
+RUN mkdir build && \
+	mkdir run && \
+	cd build && \
+	cmake -DCMAKE_INSTALL_PREFIX:PATH=/home/user/run -DCMAKE_BUILD_TYPE=Release ../src && \
+	make all install
+
+ADD scripts/run_container.sh /home/user/run_container.sh
+
+VOLUME ["/plandata"]
+
+ENTRYPOINT ["/home/user/run_container.sh"]

--- a/libmue/firstround_select.cpp
+++ b/libmue/firstround_select.cpp
@@ -32,10 +32,12 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 							  size_t slice)
 :
 	_teamcount(distance_matrix.teamcount()),
+	_round_teams(_teamcount / 3),
+	// ToDo: review this
+	_max_distance(302500),
 	_candidates(_teamcount / 3)
 {
-	max_distance = 302500;
-	unsigned int _round_teams = _teamcount / 3;
+	(void)max_distance;
 	BOOST_ASSERT(slice < _round_teams * 2);
 
 	for (Team_id host_team = 0; host_team < _round_teams; ++host_team) {
@@ -48,7 +50,7 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 		{
 			Distance firststep_distance = distance_matrix.lookup(host_team,
 									     firststep_guest);
-			if (firststep_distance > max_distance)
+			if (firststep_distance > _max_distance)
 				continue;
 
 			std::vector<Candidate> second_candidates;
@@ -59,7 +61,7 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 			{
 				Distance secondstep_distance = distance_matrix.lookup(firststep_guest,
 										      secondstep_guest);
-				if (secondstep_distance > max_distance)
+				if (secondstep_distance > _max_distance)
 					continue;
 
 				second_candidates.emplace_back(firststep_distance + secondstep_distance,

--- a/libmue/firstround_select.cpp
+++ b/libmue/firstround_select.cpp
@@ -27,19 +27,11 @@ struct Candidate
 
 }
 
-mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const &distance_matrix,
-							  Distance max_distance,
-							  size_t slice)
-:
-	_teamcount(distance_matrix.teamcount()),
-	_round_teams(_teamcount / 3),
-	// ToDo: review this
-	_max_distance(302500),
-	_candidates(_teamcount / 3)
-{
-	(void)max_distance;
-	BOOST_ASSERT(slice < _round_teams * 2);
 
+void
+mue::Firstround_team_selection::_sort_filter_teams(Distance_matrix const &distance_matrix,
+						   size_t slice)
+{
 	for (Team_id host_team = 0; host_team < _round_teams; ++host_team) {
 		std::vector<Candidate> guest_candidates;
 		guest_candidates.reserve(_round_teams * _round_teams);
@@ -107,6 +99,24 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 					{ _candidates[host_team].emplace_back(c.team); });
 
 	}
+
+}
+
+
+mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const &distance_matrix,
+							  Distance max_distance,
+							  size_t slice)
+:
+	_teamcount(distance_matrix.teamcount()),
+	_round_teams(_teamcount / 3),
+	// ToDo: review this
+	_max_distance(302500),
+	_candidates(_teamcount / 3)
+{
+	(void)max_distance;
+	BOOST_ASSERT(slice < _round_teams * 2);
+
+	_sort_filter_teams(distance_matrix, slice);
 
 	// Put back "missinng" (optimized out) teams
 

--- a/libmue/firstround_select.cpp
+++ b/libmue/firstround_select.cpp
@@ -15,13 +15,13 @@ struct Candidate
 	: distance(distance), team(team)
 	{ }
 
-	bool operator <(Candidate const &other)
+	bool operator <(Candidate const &other) const
 	{ return distance < other.distance; }
 
-	bool operator >(Candidate const &other)
+	bool operator >(Candidate const &other) const
 	{ return distance > other.distance; }
 
-	bool operator ==(Candidate const &other)
+	bool operator ==(Candidate const &other) const
 	{ return team == other.team; }
 };
 

--- a/libmue/firstround_select.cpp
+++ b/libmue/firstround_select.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <set>
 
 #include "firstround_select.h"
 
@@ -33,16 +34,16 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 	_teamcount(distance_matrix.teamcount()),
 	_candidates(_teamcount / 3)
 {
-	(void) slice;
-	unsigned int round_teams = _teamcount / 3;
-	BOOST_ASSERT(slice < round_teams * 2);
+	max_distance = 302500;
+	unsigned int _round_teams = _teamcount / 3;
+	BOOST_ASSERT(slice < _round_teams * 2);
 
-	for (Team_id host_team = 0; host_team < round_teams; ++host_team) {
+	for (Team_id host_team = 0; host_team < _round_teams; ++host_team) {
 		std::vector<Candidate> guest_candidates;
-		guest_candidates.reserve(round_teams * round_teams);
+		guest_candidates.reserve(_round_teams * _round_teams);
 
-		for (Team_id firststep_guest = round_teams;
-		     firststep_guest < 2 * round_teams;
+		for (Team_id firststep_guest = _round_teams;
+		     firststep_guest < 2 * _round_teams;
 		     ++firststep_guest)
 		{
 			Distance firststep_distance = distance_matrix.lookup(host_team,
@@ -52,8 +53,8 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 
 			std::vector<Candidate> second_candidates;
 
-			for (Team_id secondstep_guest = 2 * round_teams;
-			     secondstep_guest < 3 * round_teams;
+			for (Team_id secondstep_guest = 2 * _round_teams;
+			     secondstep_guest < 3 * _round_teams;
 			     ++secondstep_guest)
 			{
 				Distance secondstep_distance = distance_matrix.lookup(firststep_guest,
@@ -104,5 +105,45 @@ mue::Firstround_team_selection::Firstround_team_selection(Distance_matrix const 
 					{ _candidates[host_team].emplace_back(c.team); });
 
 	}
-}
 
+	// Put back "missinng" (optimized out) teams
+
+	// Make a set of "guests"
+	std::set<Team_id> present;
+	for (Team_id t = _round_teams; t < _teamcount; ++t) {
+		present.insert(t);
+	}
+
+	// filter out present teams
+	for (auto const &teams : _candidates) {
+		for (Team_id const &team : teams) {
+			present.erase(team);
+		}
+	}
+
+	// Iterate missing teams
+	for (Team_id const missing_team : present) {
+		std::vector<Candidate> candidates;
+
+		// Iterate hosts
+		for (Team_id host = 0; host < _round_teams; ++host) {
+			if (missing_team < 2 * _round_teams) {
+				// main round team
+				candidates.emplace_back(distance_matrix.lookup(host, missing_team), host);
+			} else {
+				// dessert team - we have one potential hop - so build the
+				// distances over each potential hop
+				for (Team_id hop = _round_teams; hop < 2 * _round_teams; ++hop) {
+					Distance dist = distance_matrix.lookup(host, hop)
+							+ distance_matrix.lookup(hop, missing_team);
+					candidates.emplace_back(dist, host);
+				}
+			}
+		}
+
+		// Put "best" candidate in the candidate list
+		BOOST_ASSERT(candidates.size() != 0);
+		std::sort(candidates.begin(), candidates.end());
+		_candidates[candidates[0].team].push_back(missing_team);
+	}
+}

--- a/libmue/firstround_select.h
+++ b/libmue/firstround_select.h
@@ -20,6 +20,9 @@ namespace mue {
 			const Distance _max_distance;
 			std::vector<std::vector<Team_id> > _candidates;
 
+			void _sort_filter_teams(Distance_matrix const &distance_matrix,
+						size_t slice);
+
 		public:
 			Firstround_team_selection(Distance_matrix const &distance_matrix,
 						  Distance max_distance,

--- a/libmue/firstround_select.h
+++ b/libmue/firstround_select.h
@@ -15,7 +15,9 @@ namespace mue {
 	class Firstround_team_selection
 	{
 		private:
-			unsigned int _teamcount;
+			const unsigned int _teamcount;
+			const unsigned int _round_teams;
+			const Distance _max_distance;
 			std::vector<std::vector<Team_id> > _candidates;
 
 		public:

--- a/libmue/tests/test_firstround_select.h
+++ b/libmue/tests/test_firstround_select.h
@@ -7,7 +7,7 @@
 #include "config.h"
 #include "guest_tuple_iterator.h"
 
-
+#include <iostream>
 class TestFirstroundTeamSelection : public CxxTest::TestSuite
 {
 	private:
@@ -60,11 +60,40 @@ class TestFirstroundTeamSelection : public CxxTest::TestSuite
 
 			using guests = mue::Guest_tuple_generator::GuestPair;
 
-			std::vector<guests> reference = { guests(4, 8), guests(4, 9), guests(4, 10),
-							  guests(8, 9), guests(8, 10),
-							  guests(9, 10)};
+			std::vector<guests> reference = {guests(4, 8),
+							 guests(4, 9),
+							 guests(4, 10),
+							 guests(4, 5),
+							 guests(4, 6),
+							 guests(4, 7),
+							 guests(4, 11),
+							 guests(8, 9),
+							 guests(8, 10),
+							 guests(8, 5),
+							 guests(8, 6),
+							 guests(8, 7),
+							 guests(8, 11),
+							 guests(9, 10),
+							 guests(9, 5),
+							 guests(9, 6),
+							 guests(9, 7),
+							 guests(9, 11),
+							 guests(10, 5),
+							 guests(10, 6),
+							 guests(10, 7),
+							 guests(10, 11),
+							 guests(5, 6),
+							 guests(5, 7),
+							 guests(5, 11),
+							 guests(6, 7),
+							 guests(6, 11),
+							 guests(7, 11)};
+
+
+
 			auto it = reference.begin();
 			for (guests const &g : generator) {
+				std::cout << "guests(" << (int) g.first << ", "<< (int) g.second << ")"<<std::endl;
 				TS_ASSERT(it != reference.end());
 				TS_ASSERT_EQUALS(it->first, g.first);
 				TS_ASSERT_EQUALS(it->second, g.second);

--- a/scripts/run_container.sh
+++ b/scripts/run_container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+cd $HOME/run
+
+for f in distances teams; do
+    cp "/plandata/${f}_${1}.json" .
+done
+
+LD_PRELOAD=/usr/lib/libtcmalloc_and_profiler.so.4  /usr/bin/python3.4 -OO  integration_test.py $1 | tee /plandata/output_$1
+


### PR DESCRIPTION
The firstround slice can coause some teams to be lost. This puts them back into the set of candidates.