### PR TITLE
Work on replacing dynamic allocations with static arrays

### DIFF
--- a/libmue/guest_tuple_iterator.cpp
+++ b/libmue/guest_tuple_iterator.cpp
@@ -9,7 +9,7 @@ mue::Guest_tuple_generator::Guest_tuple_generator(std::vector<Team_id> const& gu
 	_guest_end(
 		std::remove_if(_possible_guests.begin(), _possible_guests.end(),
 			[used](const Team_id t) -> bool { return used.find(t) != used.end(); }))
-{}
+{ }
 
 mue::Guest_tuple_generator::Guest_tuple_generator(std::vector<Team_id> const& guests, Used_bits const& used)
 :
@@ -17,7 +17,15 @@ mue::Guest_tuple_generator::Guest_tuple_generator(std::vector<Team_id> const& gu
 	_guest_end(
 		std::remove_if(_possible_guests.begin(), _possible_guests.end(),
 			[used](const Team_id t) -> bool { return used[t]; }))
-{}
+{ }
+
+mue::Guest_tuple_generator::Guest_tuple_generator(Guests const& guests, Used_bits const& used)
+:
+	_possible_guests(guests),
+	_guest_end(
+		std::remove_if(_possible_guests.begin(), _possible_guests.end(),
+			[used](const Team_id t) -> bool { return used[t]; }))
+{ }
 
 std::ostream& mue::operator<< (std::ostream& os, Guest_tuple_generator::GuestPair const& p)
 {

--- a/libmue/guest_tuple_iterator.h
+++ b/libmue/guest_tuple_iterator.h
@@ -11,10 +11,10 @@
 #include <bitset>
 
 #include "config.h"
+#include "team_container.h"
 
 
 namespace mue {
-
 
 class Guest_tuple_generator
 {
@@ -24,9 +24,9 @@ class Guest_tuple_generator
 		typedef std::unordered_set<Team_id> Used_set;
 
 	private:
-		typedef std::vector<Team_id>::const_iterator  Team_iterator;
+		typedef Guests::const_iterator  Team_iterator;
 
-		std::vector<Team_id> _possible_guests;
+		Guests _possible_guests;
 		Team_iterator _guest_end;
 
 	public:
@@ -98,6 +98,7 @@ class Guest_tuple_generator
 
 		Guest_tuple_generator(std::vector<Team_id> const& guests, Used_set  const& used);
 		Guest_tuple_generator(std::vector<Team_id> const& guests, Used_bits const& used);
+		Guest_tuple_generator(Guests const& guests, Used_bits const& used);
 
 		iterator begin() const { return Iterator(_possible_guests.begin(), _guest_end); }
 

--- a/libmue/team_container.h
+++ b/libmue/team_container.h
@@ -1,0 +1,83 @@
+#ifndef MUE__TEAM_CONTAINER
+#define MUE__TEAM_CONTAINER
+
+#include <array>
+#include <vector>
+
+#include <string.h>
+
+#include <boost/assert.hpp>
+
+#include "config.h"
+
+namespace mue {
+
+template <typename T, std::size_t NUM>
+class Limited_array
+{
+	private:
+		using _Value_type = T;
+		using _Array = std::array<_Value_type, NUM>;
+
+		std::size_t _len;
+		_Array _array;
+
+	public:
+		Limited_array() : _len(0) { }
+
+		Limited_array(std::size_t len) : _len(len) { BOOST_ASSERT( _len <= NUM); }
+
+		Limited_array(Limited_array<_Value_type, NUM> const &other)
+		:
+			_len(other._len),
+			_array(other._array)
+		{ }
+
+		Limited_array(std::initializer_list<_Value_type> const &values)
+		:
+			_len(values.size())
+		{
+			std::size_t idx(0);
+			for (const _Value_type& value : values)
+				_array[idx++] = value;
+		}
+
+		Limited_array(std::vector<_Value_type> const &other)
+		:
+			_len(other.size())
+		{
+			BOOST_ASSERT( _len <= NUM );
+			memcpy(_array.data(), other.data(), sizeof(_Value_type) * _len);
+		}
+
+		std::size_t size() const noexcept { return _len; }
+
+		typedef typename _Array::iterator iterator;
+		typedef typename _Array::const_iterator const_iterator;
+		typedef typename _Array::value_type value_type;
+
+		const_iterator begin() const noexcept { return _array.begin(); }
+		iterator begin() noexcept { return _array.begin(); }
+
+		const_iterator end() const noexcept { return _array.begin() + _len; }
+		iterator end() noexcept { return _array.begin() + _len; }
+
+		const value_type& operator[](std::size_t elem) const noexcept
+		{
+			BOOST_ASSERT( elem < _len );
+			return _array[elem];
+		}
+		value_type& operator[](std::size_t elem) noexcept
+		{
+			BOOST_ASSERT( elem < _len );
+			return _array[elem];
+		}
+};
+
+typedef Limited_array<Team_id, MAX_TEAMS / 3>       Hosts;
+typedef Limited_array<Team_id, (MAX_TEAMS / 3) * 2> Guests;
+typedef Limited_array<Team_id, MAX_TEAMS>           Teams;
+
+}
+
+#endif

--- a/libmue/tests/test_calculation.h
+++ b/libmue/tests/test_calculation.h
@@ -28,7 +28,7 @@ class TestCalculation : public CxxTest::TestSuite
 			mue::Calculation::Round_data round_data(mue::Calculation::SECOND,
 								std::vector<mue::Team_id>(),
 								std::vector<mue::Team_id>(),
-								std::vector<std::vector<mue::Team_id> > { std::vector<mue::Team_id>{0,1,6,8,0,0,0,0,0}});
+								mue::Calculation::Stations { mue::Teams {0,1,6,8,0,0,0,0,0}});
 
 			TS_ASSERT_EQUALS(calc.guest_distance(round_data, 3, mue::Guest_tuple_generator::GuestPair(1, 2)), 1+2);
 			TS_ASSERT_EQUALS(calc.guest_distance(round_data, 0, mue::Guest_tuple_generator::GuestPair(6, 7)), 0+0);


### PR DESCRIPTION
This work is done in context if issue #8. It saves another 10 seconds (33 instead of 44)
in my testcase (teams from group 1 from m&e v11 until the 20th solution).